### PR TITLE
Add length predicates for string length search

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -155,6 +155,31 @@ module Ransack
         type: :boolean,
         validator: proc { |v| BOOLEAN_VALUES.include?(v) },
         formatter: proc { |v| nil } }
+      ],
+      ['length_eq'.freeze, {
+        arel_predicate: 'eq'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_lt'.freeze, {
+        arel_predicate: 'lt'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_lteq'.freeze, {
+        arel_predicate: 'lteq'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_gt'.freeze, {
+        arel_predicate: 'gt'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_gteq'.freeze, {
+        arel_predicate: 'gteq'.freeze,
+        type: :integer
+        }
       ]
     ].freeze
 

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -461,6 +461,91 @@ module Ransack
       end
     end
 
+    describe 'length_eq' do
+      it 'generates a LENGTH(column) = value condition' do
+        @s.name_length_eq = 4
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) = 4/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_eq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+
+      it "works with attribute names containing 'length'" do
+        @s.length_field_length_eq = 8
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_field")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) = 8/
+      end
+    end
+
+    describe 'length_lt' do
+      it 'generates a LENGTH(column) < value condition' do
+        @s.name_length_lt = 5
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) < 5/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_lt = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
+    describe 'length_lteq' do
+      it 'generates a LENGTH(column) <= value condition' do
+        @s.name_length_lteq = 4
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 4/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_lteq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+
+      it "works with attribute names containing 'length'" do
+        @s.length_field_length_lteq = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_field")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 10/
+      end
+
+      it "works with attribute names starting with 'length'" do
+        @s.length_of_name_length_lteq = 5
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_of_name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 5/
+      end
+    end
+
+    describe 'length_gt' do
+      it 'generates a LENGTH(column) > value condition' do
+        # Use email instead of name to avoid conflict with name_length column
+        @s.email_length_gt = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("email")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) > 10/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.email_length_gt = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
+    describe 'length_gteq' do
+      it 'generates a LENGTH(column) >= value condition' do
+        # Use email instead of name to avoid conflict with name_length column
+        @s.email_length_gteq = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("email")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) >= 10/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.email_length_gteq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
     context "defining custom predicates" do
       describe "with 'not_in' arel predicate" do
         before do


### PR DESCRIPTION
## Summary
Implements predicates to search by string length as requested in #1492.

## Changes
- Added `length_eq`, `length_lt`, `length_lteq`, `length_gt`, `length_gteq` predicates
- These predicates wrap the attribute in LENGTH() or CHAR_LENGTH() function based on the database adapter
- Added comprehensive tests for all length predicates

## Usage
```ruby
# Find records where name length is less than or equal to 4
Person.ransack(name_length_lteq: 4).result

# Find records where name length equals 10
Person.ransack(name_length_eq: 10).result
```

## Database Support
- PostgreSQL/PostGIS: Uses `CHAR_LENGTH()`
- MySQL: Uses `CHAR_LENGTH()`
- SQLite and others: Uses `LENGTH()`

Closes #1492

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `length_eq`, `length_lt`, `length_lteq`, `length_gt`, `length_gteq` predicates and routes them to DB-specific `CHAR_LENGTH`/`LENGTH` functions with tests.
> 
> - **Predicates**:
>   - Add `length_eq`, `length_lt`, `length_lteq`, `length_gt`, `length_gteq` to `lib/ransack/constants.rb` (typed as `:integer`).
> - **Query building** (`lib/ransack/nodes/condition.rb`):
>   - Detect `length_` predicates and wrap attributes with `CHAR_LENGTH` (PostgreSQL/MySQL) or `LENGTH` (others) via `Arel::Nodes::NamedFunction` before applying `eq/lt/lteq/gt/gteq`.
>   - Preserve LIKE wildcard patterns by quoting values for `matches`/`does_not_match`.
> - **Tests** (`spec/ransack/predicate_spec.rb`):
>   - Add specs covering all `length_*` predicates, nil-handling, and attributes containing `length`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b45f5eed9d1162b9b75c3c9efcbf4b2eed5a276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->