### PR TITLE
Add CI with Rails 8.1 and Ruby 3.3.x, 3.4.x and 4.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         rails:
+          - 8-1-stable
           - 8-0-stable
           - v7.2.2
         ruby:
+          - 4.0.1
+          - 3.4.8
+          - 3.3.10
           - 3.2.2
           - 3.1.4
         exclude:
+          - rails: 8-1-stable
+            ruby: 3.1.4
           - rails: 8-0-stable
             ruby: 3.1.4
     env:
@@ -162,4 +168,3 @@ jobs:
           psql -h localhost -p 5432 -W postgres -c 'create database ransack;' -U postgres;
       - name: Run tests
         run: bundle exec rspec
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are advanced searching solutions around, like ElasticSearch or Algolia. **
 
 Ready to move beyond the basics? Use **advanced features** like i18n and extensive configuration options.
 
-Ransack is supported for Rails 8.0, 7.2 on Ruby 3.1 and later.
+Ransack is supported for Rails 8.1, 8.0, 7.2 on Ruby 3.1 and later.
 
 ## Installation
 

--- a/spec/ransack/search_spec.rb
+++ b/spec/ransack/search_spec.rb
@@ -476,8 +476,9 @@ module Ransack
 
         expect(real_query)
                 .to match(%r{LEFT OUTER JOIN articles ON (\('default_scope' = 'default_scope'\) AND )?articles.person_id = people.id})
+        # Rails 8.1+ / Arel 10+ use "AS" for join table aliases (e.g. "articles AS articles_people")
         expect(real_query)
-                .to match(%r{LEFT OUTER JOIN articles articles_people ON (\('default_scope' = 'default_scope'\) AND )?articles_people.person_id = parents_people.id})
+                .to match(%r{LEFT OUTER JOIN articles(\s+AS)?\s+articles_people ON (\('default_scope' = 'default_scope'\) AND )?articles_people.person_id = parents_people.id})
 
         expect(real_query)
           .to include "people.name = 'person_name_query'"
@@ -507,7 +508,9 @@ module Ransack
           WHERE (people.name = 'Ernie' AND parents_people.name = 'Test')
         SQL
         .squish
-        expect(real_query).to eq expected_query
+        # Normalize JOIN alias format: Rails 8.1+ / Arel 10+ output "AS" (e.g. "people AS parents_people")
+        normalize_join_aliases = ->(sql) { sql.gsub(/\s+AS\s+/, ' ') }
+        expect(normalize_join_aliases.call(real_query)).to eq normalize_join_aliases.call(expected_query)
       end
 
       it 'evaluates compound conditions contextually' do


### PR DESCRIPTION
for Check test status

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CI matrix expansion, docs, and test expectation tweaks; no production code paths are modified, with main risk being reduced strictness in SQL assertion coverage.
> 
> **Overview**
> Updates GitHub Actions CI to test against `rails` `8-1-stable` and additional `ruby` versions (`3.3.10`, `3.4.8`, `4.0.1`), with exclusions for unsupported combinations.
> 
> Updates specs to tolerate Rails 8.1/Arel 10 SQL output differences by accepting optional `AS` in join aliases and normalizing alias formatting before comparing expected SQL. README support statement is updated to include Rails 8.1.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e6474bf8480e22f3eacd862b5296159a973e257. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->