### PR TITLE
Feat/add length predicate

### DIFF
--- a/lib/ransack/constants.rb
+++ b/lib/ransack/constants.rb
@@ -155,6 +155,31 @@ module Ransack
         type: :boolean,
         validator: proc { |v| BOOLEAN_VALUES.include?(v) },
         formatter: proc { |v| nil } }
+      ],
+      ['length_eq'.freeze, {
+        arel_predicate: 'eq'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_lt'.freeze, {
+        arel_predicate: 'lt'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_lteq'.freeze, {
+        arel_predicate: 'lteq'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_gt'.freeze, {
+        arel_predicate: 'gt'.freeze,
+        type: :integer
+        }
+      ],
+      ['length_gteq'.freeze, {
+        arel_predicate: 'gteq'.freeze,
+        type: :integer
+        }
       ]
     ].freeze
 

--- a/spec/ransack/predicate_spec.rb
+++ b/spec/ransack/predicate_spec.rb
@@ -461,6 +461,91 @@ module Ransack
       end
     end
 
+    describe 'length_eq' do
+      it 'generates a LENGTH(column) = value condition' do
+        @s.name_length_eq = 4
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) = 4/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_eq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+
+      it "works with attribute names containing 'length'" do
+        @s.length_field_length_eq = 8
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_field")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) = 8/
+      end
+    end
+
+    describe 'length_lt' do
+      it 'generates a LENGTH(column) < value condition' do
+        @s.name_length_lt = 5
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) < 5/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_lt = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
+    describe 'length_lteq' do
+      it 'generates a LENGTH(column) <= value condition' do
+        @s.name_length_lteq = 4
+        field = "#{quote_table_name("people")}.#{quote_column_name("name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 4/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.name_length_lteq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+
+      it "works with attribute names containing 'length'" do
+        @s.length_field_length_lteq = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_field")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 10/
+      end
+
+      it "works with attribute names starting with 'length'" do
+        @s.length_of_name_length_lteq = 5
+        field = "#{quote_table_name("people")}.#{quote_column_name("length_of_name")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) <= 5/
+      end
+    end
+
+    describe 'length_gt' do
+      it 'generates a LENGTH(column) > value condition' do
+        # Use email instead of name to avoid conflict with name_length column
+        @s.email_length_gt = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("email")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) > 10/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.email_length_gt = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
+    describe 'length_gteq' do
+      it 'generates a LENGTH(column) >= value condition' do
+        # Use email instead of name to avoid conflict with name_length column
+        @s.email_length_gteq = 10
+        field = "#{quote_table_name("people")}.#{quote_column_name("email")}"
+        expect(@s.result.to_sql).to match /(CHAR_LENGTH|LENGTH)\(#{field}\) >= 10/
+      end
+
+      it 'does not generate a condition for nil' do
+        @s.email_length_gteq = nil
+        expect(@s.result.to_sql).not_to match /WHERE/
+      end
+    end
+
     context "defining custom predicates" do
       describe "with 'not_in' arel predicate" do
         before do

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -304,6 +304,8 @@ module Schema
         t.boolean  :awesome, default: false
         t.boolean  :terms_and_conditions, default: false
         t.boolean  :true_or_false, default: true
+        t.string   :length_field
+        t.string   :length_of_name
         t.timestamps null: false
       end
 


### PR DESCRIPTION
for Check test status

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes predicate-to-SQL generation in `Condition#format_predicate`, which can affect query output across adapters; however it’s scoped to predicates prefixed with `length_` and is covered by new specs.
> 
> **Overview**
> Adds new derived predicates `length_eq`, `length_lt`, `length_lteq`, `length_gt`, and `length_gteq` to allow searching by *string length*.
> 
> Updates condition building to wrap the target attribute in an adapter-specific SQL length function (`CHAR_LENGTH` for PostgreSQL/PostGIS/MySQL, otherwise `LENGTH`) when a `length_*` predicate is used, and extends specs/schema to cover the generated SQL and edge cases (nil values and column names containing/starting with `length`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c899efeb28754104b0f7580c157645989479319f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->